### PR TITLE
Issue 117

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ unzip <<zip files>>
 	
 	If you want to import only specific db version or sql version from Optimus Prime file collections hat are stored under the same directory being used for -fileslocation.  
 
-    python optimusprime.py -dataset newdatasetORexistingdataset -collectionid "" -fileslocation /<work-directory>/oracle-database-assessment-output -projectname my-awesome-gcp-project -fromdataframe -consolidatedataframes -filterbydbversion 111 -filterbysqlversion 2.0.3
+    python optimusprime.py -dataset newdatasetORexistingdataset -collectionid "" -fileslocation /<work-directory>/oracle-database-assessment-output -projectname my-awesome-gcp-project -fromdataframe -consolidatedataframes -filterbydbversion 11.1 -filterbysqlversion 2.0.3
 	
 ```
 
@@ -206,7 +206,7 @@ unzip <<zip files>>
 	*  WARNING: It will DELETE permanently ALL tables previously in the dataset. No further confirmation will be required. Use it with caution.
 * `-importcomment`: This an optional. In case you want to store any comment about the load in opkeylog table. Eg: "This is for Production import"
 * `-filterbysqlversion`: This an optional. In case you have files from multiple sql versions in the folder and you want to load only specific sql version files
-* `-filterbydbversion`: This an optional. In case you have files from multiple sql versions in the folder and you want to load only specific db version files
+* `-filterbydbversion`: This an optional. In case you have files from multiple db versions in the folder and you want to load only specific db version files
 
 
 * NOTE: If your file has elapsed time or any other string except data, fun following script to remove it

--- a/README.md
+++ b/README.md
@@ -190,7 +190,11 @@ unzip <<zip files>>
 	If you want to import various Optimus Prime file collections (From various databases) that are stored under the same directory being used for -fileslocation. Then, you can add to your command two additional flags (-fromdataframe -consolidatedataframes) and pass only "" to -collectionid. See example below:
 
 	python optimusprime.py -dataset newdatasetORexistingdataset -collectionid "" -fileslocation /<work-directory>/oracle-database-assessment-output -projectname my-awesome-gcp-project -fromdataframe -consolidatedataframes
+	
+	If you want to import only specific db version or sql version from Optimus Prime file collections hat are stored under the same directory being used for -fileslocation.  
 
+    python optimusprime.py -dataset newdatasetORexistingdataset -collectionid "" -fileslocation /<work-directory>/oracle-database-assessment-output -projectname my-awesome-gcp-project -fromdataframe -consolidatedataframes -filterbydbversion 111 -filterbysqlversion 2.0.3
+	
 ```
 
 *  `-dataset`: is the name of the dataset in Google Big Query. It is created if it does not exists. If it does already nothing to do then.
@@ -201,7 +205,10 @@ unzip <<zip files>>
 *  `-deletedataset`: This an optinal. In case you want to delete the whole existing dataset before importing the data. 
 	*  WARNING: It will DELETE permanently ALL tables previously in the dataset. No further confirmation will be required. Use it with caution.
 * `-importcomment`: This an optional. In case you want to store any comment about the load in opkeylog table. Eg: "This is for Production import"
-  
+* `-filterbysqlversion`: This an optional. In case you have files from multiple sql versions in the folder and you want to load only specific sql version files
+* `-filterbydbversion`: This an optional. In case you have files from multiple sql versions in the folder and you want to load only specific db version files
+
+
 * NOTE: If your file has elapsed time or any other string except data, fun following script to remove it
 
 ```

--- a/db_assessment/optimusprime.py
+++ b/db_assessment/optimusprime.py
@@ -76,13 +76,19 @@ def runMain(args):
             # It is True if no fatal errors were found
             resConsolidation = import_db_assessment.consolidateLos(args,transformersTablesSchema)
 
-
-
         # STEP 1: Import customer database assessment data
 
         # Optimus Prime Search Pattern to find the target CSV files to be processed
         # The default location will be dbResults if not overwritten by the argument -fileslocation
         csvFilesLocationPattern = str(args.fileslocation) + '/*' + str(args.collectionid).replace(' ','') + '.log'
+
+        # Append csvFilesLocationPattern if there are filterbysqlversion and/or filterbydbversion flag
+        if args.filterbysqlversion and args.filterbysqlversion is not None:
+            csvFilesLocationPattern = csvFilesLocationPattern.replace(str(args.fileslocation) + '/*',str(args.fileslocation) + '/*_' + str(args.filterbysqlversion) + '*')
+        if args.filterbydbversion and args.filterbydbversion is not None:
+            csvFilesLocationPattern = csvFilesLocationPattern.replace(str(args.fileslocation) + '/*',str(args.fileslocation) + '/*__' + str(args.filterbydbversion) + '*')
+
+
 
         # Getting a list of files from OS based on the pattern provided
         # This is the default directory to have all customer database results from oracle_db_assessment.sql
@@ -259,6 +265,10 @@ def argumentsParser():
     parser.add_argument("-v", "--verbose", help="increase output verbosity", action="store_true")
 
     parser.add_argument("-importcomment", type=str, default='', help="Comment for the Import")
+
+    parser.add_argument("-filterbydbversion", type=str, default='', help="To import only specific db version")
+    parser.add_argument("-filterbysqlversion", type=str, default='', help="To import only specific SQL version")
+
 
     # Execute the parse_args() method. Variable args is a namespace type
     args = parser.parse_args()

--- a/db_assessment/optimusprime.py
+++ b/db_assessment/optimusprime.py
@@ -106,11 +106,11 @@ def runMain(args):
         dbversionslist = set([f.split("__")[2].split("_")[0] for f in fileList])
         outliers = len([version for version in dbversionslist if version not in ['111','112']])
         if ("111" in dbversionslist or "112" in dbversionslist) and outliers > 0:
-            sys.exit('\nERROR:  Importing other versions along with 11.1 and 11.2 is not supported. Please use flag fileterbydbversion to filter database versions, For example: -filterbydbversion "12.1,12.2,18.0,19.1"\n'.format(csvFilesLocationPattern))
+            sys.exit('\nERROR:  Importing other versions along with 11.1 and 11.2 is not supported. Please use flag fileterbydbversion to filter database versions, For example: -filterbydbversion "12.1,12.2,18.0,19.1"\n')
 
         sqlversionslist = set([f.split("__")[2].split("_")[1] for f in fileList])
         if len(sqlversionslist) > 1:
-            sys.exit('\nERROR:  Importing multiple SQL versions is not supported. Please use flag fileterbysqlversion to filter SQL versions, For example: -filterbysqlversion 2.0.3"\n'.format(csvFilesLocationPattern))
+            sys.exit('\nERROR:  Importing multiple SQL versions is not supported. Please use flag fileterbysqlversion to filter SQL versions, For example: -filterbysqlversion 2.0.3"\n')
 
         # Getting file pattern for find config files in the OS to be imported
         csvFilesLocationPatternOPConfig = 'opConfig/*.csv'

--- a/db_assessment/optimusprime.py
+++ b/db_assessment/optimusprime.py
@@ -103,10 +103,14 @@ def runMain(args):
             sys.exit('\nERROR: There is not matching CSV file found to be processed using: {}\n'.format(csvFilesLocationPattern))
 
         #  Make sure there are not 11.2 or 11.1 database versions being imported along with other database versions.
-        versions = set([f.split("__")[2].split("_")[0] for f in fileList])
-        outliers = len([x for x in versions if x not in ['111','112']])
-        if ("111" in versions or "112" in versions) and outliers > 0:
+        dbversionslist = set([f.split("__")[2].split("_")[0] for f in fileList])
+        outliers = len([version for version in dbversionslist if version not in ['111','112']])
+        if ("111" in dbversionslist or "112" in dbversionslist) and outliers > 0:
             sys.exit('\nERROR:  Importing other versions along with 11.1 and 11.2 is not supported. Please use flag fileterbydbversion to filter database versions, For example: -filterbydbversion "12.1,12.2,18.0,19.1"\n'.format(csvFilesLocationPattern))
+
+        sqlversionslist = set([f.split("__")[2].split("_")[1] for f in fileList])
+        if len(sqlversionslist) > 1:
+            sys.exit('\nERROR:  Importing multiple SQL versions is not supported. Please use flag fileterbysqlversion to filter SQL versions, For example: -filterbysqlversion 2.0.3"\n'.format(csvFilesLocationPattern))
 
         # Getting file pattern for find config files in the OS to be imported
         csvFilesLocationPatternOPConfig = 'opConfig/*.csv'


### PR DESCRIPTION
These changes are to add below filters filterbydbversion and filterbysqlversion, and add below validations

1) Make sure ALL *log files are from the same Script version. For instance, we had a case in which the user was trying to import ALL 2.0.4 logs, however, in the middle he had some old 2.0.3.

2)Make sure there are not 11.2 or 11.1 database versions being imported along with other database versions. OP utility cannot handle those imports today using -consolidatedataframes. If that happens we should stop processing and throw a message saying this is not supported and recommend the usage of a flag to filter database versions(which does not exists today). For example: -filterbydbversion "12.1,12.2,18.0,19.1"