### PR TITLE
PR: Introduce SCRIPT_DIR var in order to derive BASE_DIR

### DIFF
--- a/db_assessment/dbSQLCollector/collectData-Step1.sh
+++ b/db_assessment/dbSQLCollector/collectData-Step1.sh
@@ -25,10 +25,10 @@ read -a mainversion <<< "$version"
 IFS=`echo ${IFS_bk}`
 dbVersion=$(( mainversion[0] + 0 ))
 
-full_path="$(dirname $(realpath $0))"
-BASE_DIR=$(/usr/bin/pwd -P); export BASE_DIR
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASE_DIR=${SCRIPT_DIR}/../..; export BASE_DIR
 OLD_ORACLE_PATH=${ORACLE_PATH}
-ORACLE_PATH=${full_path}; export ORACLE_PATH
+ORACLE_PATH=${SCRIPT_DIR}; export ORACLE_PATH
 SQL_SCRIPT="op_collect.sql"
 sqlplus -s ${connectString} @${SQL_SCRIPT}
 if [ ! -z "$OLD_ORACLE_PATH" ]; then


### PR DESCRIPTION
Determine where collectData-Step1.sh is located place path into SCRIPT_DIR and then derive BASE_DIR from that.  This allows you to run the script from anywhere and continue to have correct relative paths.