### PR TITLE
Prevent extraneous "*csv" file generation on error.

### DIFF
--- a/scripts/collector/oracle/collect-data.sh
+++ b/scripts/collector/oracle/collect-data.sh
@@ -111,8 +111,9 @@ fi
 function cleanupOpOutput  {
 V_FILE_TAG=$1
 echo "Preparing files for compression."
-for outfile in  ${OUTPUT_DIR}/*csv
+for outfile in  ${OUTPUT_DIR}/opdb*.csv
 do
+ if [ -f $outfile ] ; then
   if [ $(uname) = "SunOS" ]
   then
     sed  's/ *\|/\|/g;s/\| */\|/g;/^$/d'  ${outfile} > sed.tmp
@@ -129,6 +130,7 @@ do
     rm sed.tmp
   fi
   fi
+ fi
 done
 }
 
@@ -161,10 +163,10 @@ ZIPFILE=opdb_oracle_${DIAGPACKACCESS}__${V_FILE_TAG}${V_ERR_TAG}.zip
 cd ${OUTPUT_DIR}
 if [ ! "${ZIP}" = "" ]
 then
-  $ZIP $ZIPFILE  *csv *.log *.txt
+  $ZIP $ZIPFILE  opdb*.csv opdb*.log opdb*.txt
   OUTFILE=$ZIPFILE
 else
-  tar cvf $TARFILE  *csv *.log *.txt
+  tar cvf $TARFILE  opdb*.csv opdb*.log opdb*.txt
   $GZIP $TARFILE
   OUTFILE=${TARFILE}.gz
 fi

--- a/scripts/collector/oracle/sql/op_collect_init.sql
+++ b/scripts/collector/oracle/sql/op_collect_init.sql
@@ -221,9 +221,9 @@ set termout on
 set serveroutput on
 DECLARE
   cnt NUMBER;
-  l_tab_name VARCHAR2(100) := 'NONE';
+  l_tab_name VARCHAR2(100) := '---';
   l_col_name VARCHAR2(100);
-  the_sql VARCHAR2(1000) := 'NONE';
+  the_sql VARCHAR2(1000) := '---';
 BEGIN 
   :sp  := 'prompt_nostatspack.sql';
   IF '&v_dodiagnostics' = 'usediagnostics' THEN 
@@ -242,14 +242,14 @@ BEGIN
   BEGIN
     SELECT count(1) INTO cnt FROM user_tab_privs WHERE table_name = upper(l_tab_name);
     IF cnt = 0 THEN
-      IF l_tab_name ='NONE' THEN
-        RAISE_APPLICATION_ERROR(-20001, 'This user does not have SELECT privileges on DBA_HIST_SNAPSHOT or STATS$SNAPSHOT.  Please ensure the grants_wrapper.sql script has been executed for this user.');
+      IF l_tab_name ='---' THEN
+        dbms_output.put_line('This user does not have SELECT privileges on DBA_HIST_SNAPSHOT or STATS$SNAPSHOT.  No performance data will be collected.');
       ELSE
         RAISE_APPLICATION_ERROR(-20002, 'This user does not have SELECT privileges on ' || l_tab_name || '.  Please ensure the grants_wrapper.sql script has been executed for this user.');
       END IF;
     END IF;
   END;
-  IF (l_tab_name != 'NONE' AND l_tab_name NOT LIKE 'ERROR%') THEN
+  IF (l_tab_name != '---' AND l_tab_name NOT LIKE 'ERROR%') THEN
      THE_SQL := 'SELECT min(snap_id) , max(snap_id) FROM ' || l_tab_name || ' WHERE ' || l_col_name || ' >= (sysdate- &&dtrange ) AND dbid = :1 ';
      EXECUTE IMMEDIATE the_sql INTO  :minsnap, :maxsnap USING '&&v_dbid' ;
      IF :minsnap IS NULL THEN


### PR DESCRIPTION
Allow extraction without performance data if NoDiagnostics flag is passed and there is no STATSPACK data.